### PR TITLE
Remove maven github config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,13 +7,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven {
-        url = uri("https://maven.pkg.github.com/cashapp/quiver")
-        credentials {
-            username = System.getenv("GITHUB_USERNAME")
-            password = System.getenv("GITHUB_TOKEN")
-        }
-    }
 }
 
 kotlin {


### PR DESCRIPTION
Accidentally added maven config to download Quiver package which we don't need